### PR TITLE
chore: fixed image URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/buccaneerai/rxjs-stats/blob/master/docs/rxjs-stats.png" />
+# <img src="https://github.com/buccaneerai/rxjs-stats/raw/master/docs/rxjs-stats.png" />
 [![CircleCI](https://circleci.com/gh/buccaneerai/rxjs-stats/tree/master.svg?style=shield)](https://circleci.com/gh/buccaneerai/rxjs-stats/tree/master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 <a href="https://www.npmjs.com/package/@buccaneer/rxjs-stats">


### PR DESCRIPTION
README update